### PR TITLE
Fix YAML Configuration  (#37)

### DIFF
--- a/custom_components/kumo/__init__.py
+++ b/custom_components/kumo/__init__.py
@@ -77,6 +77,10 @@ async def async_setup(hass, config):
     username = config[DOMAIN].get(CONF_USERNAME)
     password = config[DOMAIN].get(CONF_PASSWORD)
     prefer_cache = config[DOMAIN].get(CONF_PREFER_CACHE)
+    domain_options = {
+        "connect_timeout": config[DOMAIN].get(CONF_CONNECT_TIMEOUT),
+        "response_timeout": config[DOMAIN].get(CONF_RESPONSE_TIMEOUT),
+    }
 
     # Read config from either remote KumoCloud server or
     # cached JSON.
@@ -128,7 +132,7 @@ async def async_setup(hass, config):
                 success = True
 
     if success:
-        hass.data[KUMO_DATA] = KumoData(account, config[DOMAIN])
+        hass.data[KUMO_DATA] = KumoData(account, config[DOMAIN], domain_options)
         setup_kumo(hass, config)
         return True
 

--- a/custom_components/kumo/climate.py
+++ b/custom_components/kumo/climate.py
@@ -130,12 +130,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         name = data.get_account().get_name(unit)
         address = data.get_account().get_address(unit)
         credentials = data.get_account().get_credentials(unit)
-        connect_timeout = float(
-            data.get_domain_options().get(CONF_CONNECT_TIMEOUT, None)
-        )
-        response_timeout = float(
-            data.get_domain_options().get(CONF_RESPONSE_TIMEOUT, None)
-        )
+        if data.get_domain_options().get(CONF_CONNECT_TIMEOUT) is None:
+            connect_timeout = 1.2
+        else:
+            connect_timeout = float(
+                data.get_domain_options().get(CONF_CONNECT_TIMEOUT, "1.2")
+            )
+        if data.get_domain_options().get(CONF_RESPONSE_TIMEOUT) is None:
+            response_timeout = 8.0
+        else:
+            response_timeout = float(
+                data.get_domain_options().get(CONF_RESPONSE_TIMEOUT, "8")
+            )
         kumo_api = pykumo.PyKumo(
             name, address, credentials, (connect_timeout, response_timeout)
         )


### PR DESCRIPTION
* Update requirement to HA 0.110 and change ClimateDevice to ClimateEntity

* Config Flow working form

* working config flow no errors though

* remove commented out info

* Cleanup and keep as close to original

* revert hacs version

* reenabled cache and made sure it works, more cleanup of unecessary code

* Added error check for failed connection to KumoCloud

* Added options for config flow, added workaround for floats set defaults

* Update Readme file to include ConfigFlow instructions

* Fix Yaml configuration for backwards compatibility

* Fix YAML config